### PR TITLE
Self-study courses - CLA course

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,11 @@ Advanced
 * [Some dark corners of C][210]
 * [The lost art of C structure packing][34]
 * [Writing efficient C and C code optimization][33]
+ 
+Self-study courses
+----------
+
+* [C Programming Language Certified Associate preparation course][211]
 
 ## Physical ##
 
@@ -557,3 +562,4 @@ XML
 [208]: http://nethack4.org/blog/building-c.html
 [209]: https://github.com/riolet/nope.c
 [210]: https://docs.google.com/presentation/d/1h49gY3TSiayLMXYmRMaAEMl05FaJ-Z6jDOWOz3EsqqQ/edit?pli=1#slide=id.gaf50702c_0153
+[211]: http://www.cppinstitute.org/?page_id=1487


### PR DESCRIPTION
Added "C Programming Language Certified Associate preparation course" from C++ Institute.
