### PR TITLE
Update README: Add learning resources in C reference section

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,7 @@ to C programming.
 * [Templating in C][267]
 * [What a C programmer should know about memory][227]
 * [CodeforWin: Learn C Programming, Data Structures Tutorials and Exercises online][605]
+* [Learn C: Free and Open-Source Interactive C Tutorial][606]
 
 ### Intermediate resources online ###
 
@@ -1793,3 +1794,4 @@ support for C.
 [603]: https://github.com/Hirrolot/metalang99
 [604]: https://github.com/Hirrolot/datatype99
 [605]: https://codeforwin.org/2015/09/singly-linked-list-data-structure-in-c.html
+[606]: https://www.learn-c.org

--- a/README.md
+++ b/README.md
@@ -542,6 +542,7 @@ to C programming.
 * [The GNU C Programming Tutorial][212] (online PDF)
 * [Templating in C][267]
 * [What a C programmer should know about memory][227]
+* [CodeforWin: Learn C Programming, Data Structures Tutorials and Exercises online][605]
 
 ### Intermediate resources online ###
 
@@ -1791,3 +1792,4 @@ support for C.
 [602]: https://github.com/zpl-c/zpl
 [603]: https://github.com/Hirrolot/metalang99
 [604]: https://github.com/Hirrolot/datatype99
+[605]: https://codeforwin.org/2015/09/singly-linked-list-data-structure-in-c.html


### PR DESCRIPTION
Add two websites for learning C programming:

- CodeforWin: is a good website for learning C programming, data structures tutorials, exercises, tips and tricks online. So, I added this website in C programming learning, reference, tutorials section as beginner resources online.
- Learn-C.org: is a free and open-source website for learning C programming
online for beginners. It also provides programming playground-style online code
editor for exercises and directly run C code on their website.
