### PR TITLE
Adding `cpy` to section Frameworks  

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ Big libraries that provide data structures and other stuff you expect of a
 * [C Algorithms][88] - Collection of common algorithms and data structures. [``ISC``][ISC]
 * [CPL][308] - The Common Pipeline Library; a set of libraries designed to be a
   comprehensive, efficient and robust software toolkit.
+* [cpy][] - C implementation of the methods of Python, very helpful for beginners in C.
   [``GPL-2.0-only``][GPL-2.0-only]
 * [EFL][119] - Large collection of useful data structures and
   functions. Various licenses, all open source.

--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ Big libraries that provide data structures and other stuff you expect of a
   functions. [``Apache-2.0``][Apache-2.0]
 * [C Algorithms][88] - Collection of common algorithms and data structures. [``ISC``][ISC]
 * [CPL][308] - The Common Pipeline Library; a set of libraries designed to be a
-  comprehensive, efficient and robust software toolkit.
+  comprehensive, efficient and robust software toolkit.[``GPL-2.0-only``][GPL-2.0-only]
 * [cpy][612] - Implementation of the methods & data structures of Python for scripting in C - easy to read and understand. [``MIT``][MIT]
 * [EFL][119] - Large collection of useful data structures and
   functions. Various licenses, all open source.

--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ Big libraries that provide data structures and other stuff you expect of a
   functions. [``Apache-2.0``][Apache-2.0]
 * [C Algorithms][88] - Collection of common algorithms and data structures. [``ISC``][ISC]
 * [CPL][308] - The Common Pipeline Library; a set of libraries designed to be a
-  comprehensive, efficient and robust software toolkit.[``GPL-2.0-only``][GPL-2.0-only]
+  comprehensive, efficient and robust software toolkit. [``GPL-2.0-only``][GPL-2.0-only]
 * [cpy][612] - Implementation of the methods & data structures of Python for scripting in C - easy to read and understand. [``MIT``][MIT]
 * [EFL][119] - Large collection of useful data structures and
   functions. Various licenses, all open source.

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ Big libraries that provide data structures and other stuff you expect of a
 * [C Algorithms][88] - Collection of common algorithms and data structures. [``ISC``][ISC]
 * [CPL][308] - The Common Pipeline Library; a set of libraries designed to be a
   comprehensive, efficient and robust software toolkit.
-* [cpy][612] - Implementation of the methods & data structures of Python for scripting in C - easy to read and understand.
+* [cpy][612] - Implementation of the methods & data structures of Python for scripting in C - easy to read and understand. [``MIT``][MIT]
   [``GPL-2.0-only``][GPL-2.0-only]
 * [EFL][119] - Large collection of useful data structures and
   functions. Various licenses, all open source.

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ Big libraries that provide data structures and other stuff you expect of a
 * [C Algorithms][88] - Collection of common algorithms and data structures. [``ISC``][ISC]
 * [CPL][308] - The Common Pipeline Library; a set of libraries designed to be a
   comprehensive, efficient and robust software toolkit.
-* [cpy][] - C implementation of the methods of Python, very helpful for beginners in C.
+* [cpy][612] - Implementation of the methods & data structures of Python for scripting in C - easy to read and understand.
   [``GPL-2.0-only``][GPL-2.0-only]
 * [EFL][119] - Large collection of useful data structures and
   functions. Various licenses, all open source.
@@ -1807,3 +1807,4 @@ support for C.
 [609]: https://github.com/jasmcaus/tau
 [610]: https://github.com/BayesWitnesses/m2cgen
 [611]: https://sod.pixlab.io/
+[612]: https://github.com/midnqp/cpy

--- a/README.md
+++ b/README.md
@@ -380,7 +380,6 @@ Big libraries that provide data structures and other stuff you expect of a
 * [CPL][308] - The Common Pipeline Library; a set of libraries designed to be a
   comprehensive, efficient and robust software toolkit.
 * [cpy][612] - Implementation of the methods & data structures of Python for scripting in C - easy to read and understand. [``MIT``][MIT]
-  [``GPL-2.0-only``][GPL-2.0-only]
 * [EFL][119] - Large collection of useful data structures and
   functions. Various licenses, all open source.
 * [klib][76] - Small and lightweight implementations of common algorithms and


### PR DESCRIPTION
`cpy` strives to let you do scripting like Python.