### PR TITLE
adding ceval

### DIFF
--- a/README.md
+++ b/README.md
@@ -1043,6 +1043,7 @@ A 'catch-all' category for anything that doesn't fit well anywhere else.
 * [Caffeine][496] - Library for building daemons and services for Linux and
   FreeBSD systems. [``LGPL-2.1-or-later``][LGPL-2.1-or-later]
 * [CException][298] - Implementation of exceptions. [``MIT``][MIT]
+* [ceval](https://github.com/erstan/ceval) - Library for parsing and evaluation of math expressions. [``MIT``][MIT]
 * [CommonMark][223] - Implementation of the CommonMark spec.
 * [cosmopolitan][597] - fast portable static native textmode containers (build C programs for Linux\Mac\Windows in one go)
   [Variety of licenses, all open source][224].


### PR DESCRIPTION
<https://github.com/erstan/ceval>

Ceval is a C/C++ library for parsing and evaluation of math expressions. It is primarily written in C with a very small portion written in C++ that is included only when the #include directive is from a C++ file/project. 

Math expressions consisting of floating point numbers (in decimal or exponential form), basic arithmetic operators, relational operators, logical operators and bitwise operators can be parsed using the ceval library. The expression can also contain single-argument[ `f(x)` ] and double-argument functions [ `f(x, y)` ]. 