### PR TITLE
Fix `libzip` link

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Compilers, as well as compiler- and compilation-related tooling.
   [``BSD-3-Clause``][BSD-3-Clause]
 * [fastLZ][586] - Lightning-fast lossless compression library (LZ77 type). Embbedable on small target like ARM Cortex-M families. Source code directly embbedable on your project ( a pair of h/c files), no dynamic memory allocation. [``MIT``][MIT]
 * [huffandpuff][214] - Minimal Huffman encoder and decoder. Public domain.
-* [libzip][587] - C library for reading, creating and modifying zip archives.
+* [libzip][593] - C library for reading, creating and modifying zip archives.
   [``BSD-3-Clause``][BSD-3-Clause]
 * [libbzip2][427] - Patent-free, high-quality data compression
   library. [``BSD-4-Clause``][BSD-4-Clause]


### PR DESCRIPTION
`[593]: https://libzip.org` is the right code for libzip instead of `[587]: https://github.com/maxim2266/str`