### PR TITLE
Add iLOG3 ( https://github.com/calvinwilliams/iLOG3 )

### DIFF
--- a/README.md
+++ b/README.md
@@ -1075,6 +1075,7 @@ A 'catch-all' category for anything that doesn't fit well anywhere else.
   interfaces. [``GPL-3.0-or-later``][GPL-3.0-or-later]
 * [Hoedown][405] - Fully standards-compliant, extension-supporting, UTF-8
   aware, fast Markdown parser. [``MIT``][MIT]
+* [iLOG3][615] - Standard C logging function library, portable and easy to use, high performance, multiple interfaces, native cross-platform, thread safety. [``LGPL-2.1-only``][LGPL-2.1-only]
 * [Kitsune][355] - Efficient, general-purpose framework for dynamic software
   updating. [``LGPL-3.0-or-later``][LGPL-3.0-or-later]
 * [libCello][96] - Library introducing higher-level programming to
@@ -1819,3 +1820,4 @@ support for C.
 [612]: https://github.com/michaelrsweet/pdfio
 [613]: https://github.com/rurban/ctl
 [614]: https://github.com/nakst/luigi
+[615]: https://github.com/calvinwilliams/iLOG3 


### PR DESCRIPTION
I'd like to suggest adding iLog3 ( https://github.com/calvinwilliams/iLOG3 ) into the great awesome-c list under the 'Utilities' category, because I saw 'zlog' under the same category. iLog3 is also a useful Logging library similar with zlog. In fact I used both of 'zlog' and 'iLog3' in my commercial pure C software development projects, and iLog3 is a little better than zlog in Linux and Windows cross-platform programming. And iLog3 has a very clear documentation in the doc folder and good example in README-EN. It is published as open source library with LGPL 2.1 license.

Thanks.
