### PR TITLE
add pspsdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ Big libraries that provide data structures and other stuff you expect of a
 * [sc][595] - Common libraries and data structures for C. [``MIT``][MIT]
 * [TBOX][398] - Multi-platform library with a large number of
   capabilities. [``Apache-2.0``][Apache-2.0]
+* [pspsdk][620] - An open-source SDK for PSP homebrew development. [Various licences][621].
 
 ## Game Programming ##
 
@@ -1830,3 +1831,5 @@ support for C.
 [617]: https://github.com/Cogmasters/concord
 [618]: https://github.com/solenum/exengine
 [619]: https://projects.malikania.fr/bcc
+[620]: https://github.com/pspdev/pspsdk
+[621]: https://github.com/pspdev/pspsdk/blob/master/LICENSE


### PR DESCRIPTION
This is a various licenses, according [here](https://github.com/pspdev/pspsdk#introduction). this is what it says:

> PSPSDK is distributed under a BSD-compatible license, with the exception of the files located in tools/PrxEncrypter. The files located in the tools/PrxEncrypter directory are subject to the terms of the GNU General Public License version 3. See the LICENSE files for more information.