### PR TITLE
Updated link to point to the source code repository of WhiteDB.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1722,7 +1722,7 @@ support for C.
 [509]: https://github.com/spotify/sparkey
 [510]: http://facebook.github.io/zstd/
 [511]: https://libvips.github.io/libvips/
-[512]: http://whitedb.org/
+[512]: https://github.com/priitj/whitedb
 [513]: http://paulbatchelor.github.io/proj/soundpipe.html
 [514]: https://github.com/atomicobject/heatshrink
 [515]: http://ebassi.github.io/graphene/


### PR DESCRIPTION
The previous link directed to a website that appeared to be irrelevant to the in-memory database. This commit replaces it with a link to the WhiteDB source code repository, providing users with direct access to the relevant codebase.