### PR TITLE
Adding nappgui

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,7 @@ Widget toolkits, or things meant to be used in a similar way to them.
 * [GTK+][14] - Cross-platform widget toolkit. [``LGPL-2.1-only``][LGPL-2.1-only]
 * [IUP][16] - Another cross-platform widget toolkit. [``MIT``][MIT]
 * [microui][616] - Tiny immediate-mode UI library written in portable ANSI C. [```MIT```][MIT]
+* [nappgui][705] - Professional SDK to build cross-platform desktop applications using C. [``MIT``][MIT]
 * [nuklear][408] - Small, C89, single-header widget toolkit. Public domain.
 * [tinyfiledialogs][426] - Single-file library for simple dialogs. Compatible
   with many other toolkits and OSes. [``Zlib``][Zlib]
@@ -1843,4 +1844,5 @@ support for C.
 [702]: https://duckdb.org/
 [703]: https://github.com/armink/FlashDB
 [704]: https://github.com/taosdata/TDengine
+[705]: https://nappgui.com/
 


### PR DESCRIPTION
Adding NAppGUI 

NAppGUI is a professional SDK to build cross-platform desktop applications using The C Programming Language (ANSI C90). 

NAppGUI is built as a lightweight layer on top of the operating system native APIs, that allows create portable programs extremely fast and small without any external dependency.