### PR TITLE
Add logging, terminal spinner/indicator libraries, and github sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1161,7 +1161,7 @@ A 'catch-all' category for anything that doesn't fit well anywhere else.
 * [EasyLogger][706] - An ultra-lightweight, high-performance C/C++ log library. [``MIT``][MIT]
 * [liblogger][707] - Fast JSON structured logger [``BSD-2-Clause``][BSD-2-Clause]
 * [libspinner][708] - 90+ configurable terminal spinners and progress indicators [``BSD-2-Clause``][BSD-2-Clause]
-
+* [libgithub][709] - Library to integrate with Github's REST API [``BSD-2-Clause``][BSD-2-Clause]
 ## Web Frameworks ##
 
 Comprehensive and integrated solutions for building the next brilliant web
@@ -1851,3 +1851,4 @@ support for C.
 [706]: https://github.com/armink/EasyLogger
 [707]: https://github.com/briandowns/liblogger
 [708]: https://github.com/briandowns/libspinner
+[709]: https://github.com/briandowns/libgithub

--- a/README.md
+++ b/README.md
@@ -1160,6 +1160,7 @@ A 'catch-all' category for anything that doesn't fit well anywhere else.
 * [Datatype99][604] - Algebraic data types for C99. [``MIT``][MIT]
 * [EasyLogger][706] - An ultra-lightweight, high-performance C/C++ log library. [``MIT``][MIT]
 * [liblogger][707] - Fast JSON structured logger [``BSD-2-Clause``][BSD-2-Clause]
+* [libspinner][708] - 90+ configurable terminal spinners and progress indicators [``BSD-2-Clause``][BSD-2-Clause]
 
 ## Web Frameworks ##
 
@@ -1849,3 +1850,4 @@ support for C.
 [705]: https://nappgui.com/
 [706]: https://github.com/armink/EasyLogger
 [707]: https://github.com/briandowns/liblogger
+[708]: https://github.com/briandowns/libspinner

--- a/README.md
+++ b/README.md
@@ -1159,6 +1159,7 @@ A 'catch-all' category for anything that doesn't fit well anywhere else.
 * [Metalang99][603] - Full-blown preprocessor metaprogramming. [``MIT``][MIT]
 * [Datatype99][604] - Algebraic data types for C99. [``MIT``][MIT]
 * [EasyLogger][706] - An ultra-lightweight, high-performance C/C++ log library. [``MIT``][MIT]
+* [liblogger][707] - Fast JSON structured logger [``BSD-2-Clause``][BSD-2-Clause]
 
 ## Web Frameworks ##
 
@@ -1847,4 +1848,4 @@ support for C.
 [704]: https://github.com/taosdata/TDengine
 [705]: https://nappgui.com/
 [706]: https://github.com/armink/EasyLogger
-
+[707]: https://github.com/briandowns/liblogger


### PR DESCRIPTION
This PR adds 3 new entries. 1 for liblogger which is a JSON structured logger, 1 for libspinner which is a terminal spinner/progress indicator library, and another to interact with the Github API.