### PR TITLE
Add JsonX: JSON mapping layer for MCU/RTOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -927,6 +927,7 @@ This includes libraries for things like XML, JSON, CSV, and other similar format
   Schema. [``LGPL-2.0-or-later``][LGPL-2.0-or-later] or
   [``LGPL-2.1-or-later``][LGPL-2.1-or-later] or [``LGPL-3.0-or-later``][LGPL-3.0-or-later]
 * [YAJL][60] - Fast streaming JSON parser library. [``ISC``][ISC]
+* [JsonX](https://github.com/embedmind/JsonX) - Lightweight JSON mapping layer for microcontrollers and RTOS. Thin wrapper around cJSON with static memory pools and struct  mapping. [``MIT``][MIT]
 
 ### INI ###
 


### PR DESCRIPTION
This PR adds JsonX, a thin wrapper around cJSON designed for embedded projects.

Automatic mapping JSON <> C structures

Works without dynamic memory (baremetal mode) or with custom allocators (ThreadX/FreeRTOS/Posix)

Focused on minimal footprint and predictable memory usage on microcontrollers

JsonX is especially useful in STM32 + RTOS environments, where memory control and deterministic behavior are critical.