### PR TITLE
Adding sbor - A project manager for C (MIT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1010,6 +1010,7 @@ extensions that make it more pleasant. These are labelled by editor.
 Useful programs to help you write and debug C code which are *not* editors,
 libraries or compilers.
 
+* [Sbor][709] - Project manager for C, inspired by `cargo`.[``MIT``][MIT]
 * [Artistic Style][314] - Fast and small automatic source code formatter that
   supports C. [``LGPL-3.0-only``][LGPL-3.0-only]
 * [address-sanitizer][288] - Fast memory error detector.
@@ -1851,3 +1852,4 @@ support for C.
 [706]: https://github.com/armink/EasyLogger
 [707]: https://github.com/OCamlPro/owi
 [708]: https://hal.science/hal-04627413
+[709]: https://github.com/Vaishnav-Sabari-Girish/sbor


### PR DESCRIPTION
Hi @oz123 , 

Thank you for this wonderful list. I wanted to add my own poject (Written in C for C). 

Meet `sbor` a project manager for C, inspired by `cargo`. 

It provides commands like `init`, `build`, `run` and `clean`. 