### PR TITLE
Add miniwtpc to Multimedia

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,6 +672,7 @@ to do with managing C memory lives here.
 * [lodepng][69] - Simple PNG image decoder and encoder, requiring no other
   dependencies. [``BSD-3-Clause``][BSD-3-Clause]
 * [minimp3][536] - Lightweight MP3 decoder single header library. [``CC0-1.0``][CC0-1.0]
+* [miniwtpc][711] - Small Wavelet Thumbnail & Preview Codec single header library. Public domain/[``MIT``][MIT]
 * [Soundpipe][513] - Lightweight music DSP library. [``MIT``][MIT]
 
 ## Networking and Internet ##
@@ -1856,3 +1857,4 @@ support for C.
 [708]: https://hal.science/hal-04627413
 [709]: https://github.com/an-dr/microlog
 [710]: https://github.com/Nouridin/vfs_pipe
+[711]: https://github.com/lieff/miniwtpc


### PR DESCRIPTION
A simple, drop-in image codec in the style of stb_image (single header library).
It targets low sizes from 200 B to 36 KB at resolutions around 256x256.
The main target for thumbnails is 1400 B -- designed to fit within one MTU
packet, so the user sees *something* while the main preview downloads.
