### PR TITLE
Remove libdill from library list

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,6 @@ Compilers, as well as compiler- and compilation-related tooling.
 * [libconcurrent][390] - Concurrent programming library, using coroutines, for
   C11. [``BSD-3-Clause``][BSD-3-Clause]
 * [libcsp][572] - High performance concurrency C library influenced by the CSP model. [``MIT``][MIT]
-* [libdill][442] - Library which makes structured concurrent programming
-  easy. [``MIT``][MIT]
 * [libhl][478] - Library implementing a thread-safe API to manage a range of data
   structures. Also provides some supporting functions and structures for
   concurrent and lockfree programming. [``LGPL-3.0-only``][LGPL-3.0-only]
@@ -1664,7 +1662,6 @@ support for C.
 [439]: https://github.com/clMathLibraries/clBLAS
 [440]: https://criu.org/Main_Page
 [441]: https://github.com/neomake/neomake
-[442]: http://libdill.org/
 [443]: https://nullprogram.com/blog/2015/02/17
 [444]: https://github.com/ands/lightmapper
 [445]: http://blosc.org/pages/blosc-in-depth


### PR DESCRIPTION
I have noticed an issue (#369) where they say `Libdill` is a bad link that leads you to a suspicious website.

I have checked it myself, and it is leading nowhere. So I have removed it myself

<img width="1779" height="922" alt="image" src="https://github.com/user-attachments/assets/44e755f9-54c0-44c0-a49b-c3af97c4b840" />

